### PR TITLE
default metrics are too noisy

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -57,9 +57,6 @@ func NewRegistry(logger *log.Logger, opts ...RegistryOption) *Registry {
 	registry := prometheus.NewRegistry()
 	pr.registerer = registry
 
-	pr.registerer.MustRegister(prometheus.NewGoCollector())
-	pr.registerer.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
-
 	pr.mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{
 		Registry: pr.registerer,
 	}))


### PR DESCRIPTION
- they also largely give the same metrics as system-metrics release but in unnessesary levels of detail

Signed-off-by: Ben Fuller <benjaminf@vmware.com>

# Description

Please include a summary of the change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [x] Integration tests
- [x] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

