### PR TITLE
Adjust metric name validation unit test

### DIFF
--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -107,11 +107,11 @@ var _ = Describe("PrometheusMetrics", func() {
 		r := metrics.NewRegistry(l)
 
 		Expect(func() {
-			r.NewCounter("test-counter", "help text goes here")
+			r.NewCounter("test-a\xc5zcounter", "help text goes here")
 		}).To(Panic())
 
 		Expect(func() {
-			r.NewGauge("test-counter", "help text goes here")
+			r.NewGauge("test-a\xc5zcounter", "help text goes here")
 		}).To(Panic())
 	})
 


### PR DESCRIPTION
# Description

The metric name validation unit test had to be adjusted as the
validation in the Prometheus Go Client Library was [changed](https://github.com/prometheus/client_golang/releases/tag/v1.21.0) and now all the UTF8 characters are valid in the name of the metrics.

The name of the metric in the test was adjusted as per [this](https://github.com/prometheus/common/blob/main/model/metric_test.go#L144) unit test in the Prometheus common repo.


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [X] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
